### PR TITLE
[#14] 로그 추적  재시도 로직을 위한 AOP 구현

### DIFF
--- a/src/main/java/com/flab/CommerceCore/common/annotation/LogRepositoryError.java
+++ b/src/main/java/com/flab/CommerceCore/common/annotation/LogRepositoryError.java
@@ -1,0 +1,11 @@
+package com.flab.CommerceCore.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LogRepositoryError {
+}

--- a/src/main/java/com/flab/CommerceCore/common/aop/RepositoryErrorLogger.java
+++ b/src/main/java/com/flab/CommerceCore/common/aop/RepositoryErrorLogger.java
@@ -1,0 +1,34 @@
+package com.flab.CommerceCore.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class RepositoryErrorLogger {
+
+  @Around("@within(com.flab.CommerceCore.common.annotation.LogRepositoryError)")
+  public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+    int maxAttempt = 5;
+    int attempt = 0;
+
+    while (true) {
+      try {
+        // 메서드 실행
+        return joinPoint.proceed();
+      } catch (DataAccessException error) {
+        attempt++;
+        if (attempt > maxAttempt) {
+          log.error("[Exception in {}] - Message: {}", joinPoint.getSignature(), error.getMessage());
+          throw error; // 예외 재발생시켜 예외 처리기로 전달
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/flab/CommerceCore/common/exceptions/ErrorCode.java
+++ b/src/main/java/com/flab/CommerceCore/common/exceptions/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   // Data Access 계층 예외
+  DATA_ACCESS_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"서버에 오류가 발생했습니다.",""),
   DATA_ACCESS_RESOURCE_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "데이터베이스 리소스에 접근할 수 없습니다.", ""),
   DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "데이터 무결성 제약 조건 위반", ""),
 

--- a/src/main/java/com/flab/CommerceCore/common/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/CommerceCore/common/exceptions/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ package com.flab.CommerceCore.common.exceptions;
 import static com.flab.CommerceCore.common.exceptions.ErrorCode.*;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -35,6 +36,11 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorCode> handleDataIntegrityViolationException(DataIntegrityViolationException e){
     log.error("데이터 무결성 제약 조건 위반",e);
     return new ResponseEntity<>(DATA_INTEGRITY_VIOLATION,HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(DataAccessException.class)
+  public ResponseEntity<ErrorCode> handleDataAccessException(DataAccessException e){
+    return new ResponseEntity<>(DATA_ACCESS_EXCEPTION,HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
 

--- a/src/main/java/com/flab/CommerceCore/user/repository/UserRepository.java
+++ b/src/main/java/com/flab/CommerceCore/user/repository/UserRepository.java
@@ -1,11 +1,13 @@
 package com.flab.CommerceCore.user.repository;
 
+import com.flab.CommerceCore.common.annotation.LogRepositoryError;
 import com.flab.CommerceCore.user.domain.entity.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@LogRepositoryError
 public class UserRepository {
 
     @PersistenceContext


### PR DESCRIPTION
데이터 액세스 레벨에서 발생하는 예외를 처리하고, 재시도를 통해 복구를 시도하는 기능을 AOP를 사용하여 구현했습니다. 만약 재시도를 통해 복구할 수 없는 경우, 로그를 남기고 글로벌 예외 처리기로 예외를 전달하여 사용자에게 오류 메시지를 응답하도록 구현했습니다.

**구현**:
- AOP 기반 재시도 로직 구현:
@LogRepositoryError 어노테이션이 붙은 리포지토리의 예외에 대해 AOP를 사용하여 재시도 로직을 적용
DataAccessException이 발생하면 최대 5회까지 메서드 실행을 시도하도록 설정

- 오류 로그 기록:
재시도 횟수를 초과하면 해당 오류를 로그에 기록

- 커스텀 어노테이션 추가:
리포지토리 클래스에 오류 로깅 및 재시도 로직을 적용하기 위한 @LogRepositoryError 어노테이션 추가

- 글로벌 예외 처리:
컨트롤러에서 DataAccessException을 처리하는 ExceptionHandler를 추가 에러 응답

**추후 작업 필요**:

- 테스트 추가:
구현된 로직이 의도한 대로 작동하는지 추가적인 테스트

- 예외 처리 최적화:
재시도가 필요한 예외와 그렇지 않은 예외를 구분하여, 데이터 액세스 레벨에서 불필요한 재시도가 발생하지 않도록 서비스 및 컨트롤러 레벨에서 사전에 처리 
예) 잘못된 입력의 경우 재시도가 필요하지 않으므로, 컨트롤러에서 사전 검사로 이를 처리


