### PR TITLE
Entity의 DTO 매핑을 위한 Mapper 클래스 생성

### DIFF
--- a/src/main/java/com/flab/CommerceCore/common/Mapper/UserMapper.java
+++ b/src/main/java/com/flab/CommerceCore/common/Mapper/UserMapper.java
@@ -1,0 +1,42 @@
+package com.flab.CommerceCore.common.Mapper;
+
+import com.flab.CommerceCore.user.domain.dto.UserRequest;
+import com.flab.CommerceCore.user.domain.dto.UserResponse;
+import com.flab.CommerceCore.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+  /**
+   * UserRequest DTO를 User 엔티티로 변환하는 메서드
+   *
+   * @param userRequest 사용자 요청 정보
+   * @return 변환된 User 엔티티
+   */
+  public User convertRequestToEntity(UserRequest userRequest) {
+    return User.builder()
+        .name(userRequest.getName())
+        .email(userRequest.getEmail())
+        .password(userRequest.getPassword())
+        .phoneNum(userRequest.getPhoneNum())
+        .address(userRequest.getAddress())
+        .build();
+  }
+
+  /**
+   * User 엔티티를 UserResponse DTO로 변환하는 메서드
+   *
+   * @param user 변환할 User 엔티티
+   * @return 변환된 UserResponse DTO
+   */
+  public UserResponse convertEntityToResponse(User user) {
+    return UserResponse.builder()
+        .userId(user.getUserId())
+        .name(user.getName())
+        .email(user.getEmail())
+        .phoneNum(user.getPhoneNum())
+        .address(user.getAddress())
+        .build();
+  }
+}

--- a/src/main/java/com/flab/CommerceCore/user/service/UserService.java
+++ b/src/main/java/com/flab/CommerceCore/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.flab.CommerceCore.user.service;
 
+import com.flab.CommerceCore.common.Mapper.UserMapper;
 import com.flab.CommerceCore.common.exceptions.BusinessException;
 import com.flab.CommerceCore.common.exceptions.ErrorCode;
 import com.flab.CommerceCore.user.domain.dto.UserRequest;
@@ -16,11 +17,13 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
   @Autowired
-  public UserService(UserRepository userRepository){
+  public UserService(UserRepository userRepository, UserMapper mapper){
     this.userRepository = userRepository;
+    this.mapper = mapper;
   }
 
   private final UserRepository userRepository;
+  private final UserMapper mapper;
 
   /**
    * User 생성 메서드
@@ -36,10 +39,10 @@ public class UserService {
         throw new BusinessException(ErrorCode.DUPLICATED_USER_EMAIL);
     }
 
-    User user = convertRequestToEntity(userRequest);
+    User user = mapper.convertRequestToEntity(userRequest);
     User saveUser = userRepository.save(user);
 
-    return convertEntityToResponse(saveUser);
+    return mapper.convertEntityToResponse(saveUser);
   }
 
   /**
@@ -59,7 +62,7 @@ public class UserService {
       throw new BusinessException(ErrorCode.USERID_NOT_FOUND);
     }
 
-    return convertEntityToResponse(findUser);
+    return mapper.convertEntityToResponse(findUser);
   }
 
   /**
@@ -78,39 +81,7 @@ public class UserService {
       throw new BusinessException(ErrorCode.USERID_NOT_FOUND);
     }
 
-    findUser.updateUser(userRequest);
-    return convertEntityToResponse(findUser);
+    return mapper.convertEntityToResponse(findUser.updateUser(userRequest));
   }
 
-  /**
-   * UserRequest DTO를 User 엔티티로 변환하는 메서드
-   *
-   * @param userRequest 사용자 요청 정보
-   * @return 변환된 User 엔티티
-   */
-  private User convertRequestToEntity(UserRequest userRequest) {
-    return User.builder()
-        .name(userRequest.getName())
-        .email(userRequest.getEmail())
-        .password(userRequest.getPassword())
-        .phoneNum(userRequest.getPhoneNum())
-        .address(userRequest.getAddress())
-        .build();
-  }
-
-  /**
-   * User 엔티티를 UserResponse DTO로 변환하는 메서드
-   *
-   * @param user 변환할 User 엔티티
-   * @return 변환된 UserResponse DTO
-   */
-  private UserResponse convertEntityToResponse(User user) {
-    return UserResponse.builder()
-        .userId(user.getUserId())
-        .name(user.getName())
-        .email(user.getEmail())
-        .phoneNum(user.getPhoneNum())
-        .address(user.getAddress())
-        .build();
-  }
 }

--- a/src/test/java/com/flab/CommerceCore/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/CommerceCore/user/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.flab.CommerceCore.common.Mapper.UserMapper;
 import com.flab.CommerceCore.common.exceptions.BusinessException;
 import com.flab.CommerceCore.user.domain.dto.UserRequest;
 import com.flab.CommerceCore.user.domain.dto.UserResponse;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -25,11 +27,15 @@ class UserServiceTest {
   @Mock
   UserRepository userRepository;
 
+  @Mock
+  UserMapper mapper;
+
   @InjectMocks
   UserService userService;
 
   private User user;
   private UserRequest userRequest;
+  private UserResponse userResponse;
 
   private static final String NAME = "kim";
   private static final String EMAIL = "kim@gmail.com";
@@ -54,6 +60,14 @@ class UserServiceTest {
         .phoneNum(PHONE_NUM)
         .address(ADDRESS)
         .build();
+
+    userResponse = UserResponse.builder()
+        .userId(1L)
+        .name(NAME)
+        .email(EMAIL)
+        .phoneNum(PHONE_NUM)
+        .address(ADDRESS)
+        .build();
   }
 
   @Test
@@ -72,13 +86,29 @@ class UserServiceTest {
   }
 
   @Test
+  void createUser_Fail_Repository_Error(){
+    // given: userRepository 의 save 메서드에서 예외가 발생하도록 설정
+    when(userRepository.findByEmail(EMAIL)).thenReturn(null);
+    when(userRepository.save(any(User.class))).thenThrow(new DataAccessException("data access error") {});
+    when(mapper.convertRequestToEntity(userRequest)).thenReturn(user);
+
+    // when & then: createUser 메서드를 호출할 때 예외가 발생해야 함
+    assertThrows(DataAccessException.class, () -> {
+      userService.createUser(userRequest);
+    });
+
+    verify(userRepository, times(1)).save(any(User.class));
+  }
+
+  @Test
   void createUser_Success(){
     // given: 이메일이 중복되지 않은 경우
     when(userRepository.findByEmail(EMAIL)).thenReturn(null);
     when(userRepository.save(any(User.class))).thenReturn(user);
-
+    when(mapper.convertRequestToEntity(userRequest)).thenReturn(user);
+    when(mapper.convertEntityToResponse(user)).thenReturn(userResponse);
     // when: 새로운 User 를 생성
-    UserResponse userResponse = userService.createUser(userRequest);
+    userResponse = userService.createUser(userRequest);
 
     // then: 사용자가 정상적으로 생성되고 저장되었는지 확인
     assertNotNull(userResponse);
@@ -87,6 +117,7 @@ class UserServiceTest {
 
     verify(userRepository, times(1)).findByEmail(EMAIL);
     verify(userRepository, times(1)).save(any(User.class));
+    verify(mapper, times(1)).convertRequestToEntity(userRequest);
 
   }
 
@@ -106,18 +137,33 @@ class UserServiceTest {
   }
 
   @Test
+  void findUser_Fail_Repository_Error(){
+    //given : userRepository 의 findByUserId 메서드에서 예외가 발생하도록 설정
+    when(userRepository.findByUserId(1L)).thenThrow(new DataAccessException("data access error") {});
+
+    // when & then: findUserByUserId 메서드를 호출할 때 예외가 발생해야 함
+    assertThrows(DataAccessException.class, ()->{
+      userService.findUserByUserId(1L);
+    });
+
+    verify(userRepository, times(1)).findByUserId(1L);
+  }
+
+  @Test
   void findUser_Success(){
     // given: 사용자가 존재하는 경우
     when(userRepository.findByUserId(1L)).thenReturn(user);
+    when(mapper.convertEntityToResponse(user)).thenReturn(userResponse);
 
     // when: 사용자를 조회
-    UserResponse userResponse = userService.findUserByUserId(1L);
+    userResponse = userService.findUserByUserId(1L);
 
     // then: 조회된 사용자가 정상적인지 확인
     assertNotNull(userResponse);
     assertEquals(user.getEmail(), userResponse.getEmail());
 
     verify(userRepository, times(1)).findByUserId(1L);
+    verify(mapper, times(1)).convertEntityToResponse(user);
   }
 
   @Test
@@ -131,17 +177,29 @@ class UserServiceTest {
         .address("계양구")
         .build();
 
+    UserResponse response = UserResponse.builder()
+        .userId(1L)
+        .name("park")
+        .email("park@gmail.com")
+        .phoneNum("123-456-789")
+        .address("계양구")
+        .build();
+
     when(userRepository.findByUserId(1L)).thenReturn(user);
+    when(mapper.convertEntityToResponse(user)).thenReturn(response);
 
     // when: 사용자를 업데이트
-    UserResponse userResponse = userService.updateUser(1L, updateRequestUser);
+    userResponse = userService.updateUser(1L, updateRequestUser);
 
     // then: 업데이트된 사용자의 정보가 일치하는지 확인
     assertNotNull(userResponse);
     assertEquals(updateRequestUser.getEmail(), userResponse.getEmail());
 
     verify(userRepository, times(1)).findByUserId(1L);
+    verify(mapper, times(1)).convertEntityToResponse(user);
   }
+
+
 
 
 


### PR DESCRIPTION
코드 리뷰를 보고 DTO와 Entity의 Mapping이 어디에서 이루어지는게 확장성 및 의존성 측면에서 가장 이상적인지 조사해봤습니다.

### Controller 계층
- 확장성 : 컨트롤러는 주로 요청을 처리하고 응답을 반환하는 역할을 맡고 있어  DTO 변환 로직을 포함하면 컨트롤러가 복잡해져 확장성이 떨어집니다.
- 의존성 : 컨트롤러가 엔티티와 DTO에 직접적으로 의존하게 되므로, 의존성이 높아집니다.

### Service 계층
- 확장성 : 서비스 계층에서 DTO로 변환하는건 흐름상 자연스럽지만 마찬가지로 서비스가 복잡해져 확장성이 떨어집니다.
- 의존성 : 서비스 계층이 DTO와 엔티티에 모두 의존하게 되므로, 의존성이 높아집니다.

### Repository 계층
- 확장성 : 만약 JPA에서 Mybatis로 변경될 경우 매핑 로직을 수정해야 할 가능성이 있어 확장성이 떨어집니다.
- 의존성 : 리포지토리 계층이 DTO와 엔티티에 모두 의존하게 되므로, 의존성이 높아집니다.

### Entity
엔티티는 DB와 직접적으로 매핑하기 때문에 엔티티의 변경이 애플리케이션 전체에 영향을 줄 수 있어 DTO 변환 위치로는 좋지 않습니다.

### Mapper 클래스
매퍼 클래스를 사용하면 DTO 변환 로직이 한 곳에 모여 있기 때문에 확장성이 좋고,  매퍼 클래스는 독립적으로 존재하기 때문에 다른 클래스에 의존하지 않습니다.