### PR TITLE
[#23] CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,55 @@
+name: CI/CD Pipeline for CommerceCore
+
+on:
+  push:
+    branches:
+      - main  # main 브랜치에 푸시될 때 실행
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. 코드 체크아웃 (최신 코드 가져오기)
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # 2. Java 17 환경 설정 (CommerceCore가 Spring Boot 기반이므로 JDK 필요)
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+
+      # 3. Gradle 빌드 (Spring Boot 애플리케이션 빌드)
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      # 4. Docker 이미지 빌드 (Docker 이미지 생성)
+      - name: Build Docker image
+        run: docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/commercecore .
+
+      # 5. Docker Hub 로그인 (로그인 후 이미지 푸시)
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+
+      # 6. Docker 이미지 푸시 (Docker Hub에 이미지 업로드)
+      - name: Push Docker image
+        run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/commercecore
+
+  deploy:
+    needs: build  # build 작업이 완료된 후 deploy 작업 실행
+    runs-on: ubuntu-latest
+
+    steps:
+      # 7. SSH를 통해 NCP 서버로 접속 및 배포
+      - name: SSH to Server and Deploy
+        uses: appleboy/ssh-action@v0.1.3
+        with:
+          host: ${{ secrets.WAS_01_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/commercecore  # 새로운 이미지 가져오기
+            docker stop commercecore || true  # 기존 컨테이너 중지
+            docker rm commercecore || true    # 기존 컨테이너 제거
+            docker run -d --name commercecore -p 8090:8090 ${{ secrets.DOCKER_HUB_USERNAME }}/commercecore  # 새로운 컨테이너 실행


### PR DESCRIPTION
GitHub Actions 기반의  CI/CD 파이프라인을 추가했습니다.
이 파이프라인은 main 브랜치에 푸시되면  Spring Boot 애플리케이션을 빌드하고, 테스트한 후, Docker 컨테이너로 NCP(Naver Cloud Platform) 서버에 배포하도록 했습니다. 
GitHub Secrets를 사용하여 Docker Hub 자격 증명과 NCP 서버 접속 정보를 안전하게 관리했습니다.
기존 컨테이너가 있더라도 배포 과정에서 중지 및 삭제 후 새로운 이미지로 실행되므로 안정적인 배포가 가능합니다.


### CI 빌드 및 테스트

main 브랜치에 푸시되면 자동으로 빌드가 실행됩니다.
Java 17 환경에서 Spring Boot 애플리케이션을 Gradle을 사용해 빌드합니다.
빌드 결과물은 Docker 이미지를 생성하는 데 사용됩니다.

### Docker 이미지 관리
빌드된 애플리케이션을 기반으로 Docker 이미지를 생성하고, 자동으로 Docker Hub에 푸시됩니다.


### CD 배포

NCP 서버에 SSH로 연결하여 기존 컨테이너를 중지 및 삭제한 후, 새로운 Docker 이미지를 배포합니다.
8090 포트에서 Spring Boot 애플리케이션이 실행됩니다.


